### PR TITLE
Strip IP address from errors

### DIFF
--- a/redgifs/const.py
+++ b/redgifs/const.py
@@ -27,3 +27,8 @@ import re
 REDGIFS_THUMBS_RE = re.compile(
     r'https:\/\/thumbs\d+?\.redgifs\.com\/(?P<id>\w+)(?P<type>-\w+)?\.(?P<ext>\w+)(\?.+(\d|\w))?'
 )
+
+# https://stackoverflow.com/a/36760050
+IP_ADDR_RE = re.compile(
+    r'((25[0-5]|(2[0-4]|1[0-9]|[1-9]|)[0-9])(\.(?!$)|$)){4}$'
+)

--- a/redgifs/const.py
+++ b/redgifs/const.py
@@ -27,8 +27,3 @@ import re
 REDGIFS_THUMBS_RE = re.compile(
     r'https:\/\/thumbs\d+?\.redgifs\.com\/(?P<id>\w+)(?P<type>-\w+)?\.(?P<ext>\w+)(\?.+(\d|\w))?'
 )
-
-# https://stackoverflow.com/a/36760050
-IP_ADDR_RE = re.compile(
-    r'((25[0-5]|(2[0-4]|1[0-9]|[1-9]|)[0-9])(\.(?!$)|$)){4}$'
-)

--- a/redgifs/http.py
+++ b/redgifs/http.py
@@ -40,6 +40,7 @@ from . import __version__
 from .errors import HTTPException
 from .enums import Tags, Order
 from .const import REDGIFS_THUMBS_RE
+from .utils import strip_ip
 
 _log = logging.getLogger(__name__)
 
@@ -221,7 +222,7 @@ class HTTP:
             match = re.match(REDGIFS_THUMBS_RE, str_url)
             if match:
                 return (dl(str_url))
-            raise TypeError(f'"{str_url}" is an invalid RedGifs URL.')
+            raise TypeError(f'"{strip_ip(str_url)}" is an invalid RedGifs URL.')
 
         # If it's a 'watch' URL
         if 'watch' in yarl_url.path:
@@ -304,7 +305,7 @@ class AsyncHttp(HTTP):
             match = re.match(REDGIFS_THUMBS_RE, str_url)
             if match:
                 return (await dl(str_url))
-            raise TypeError(f'"{str_url}" is an invalid RedGifs URL.')
+            raise TypeError(f'"{strip_ip(str_url)}" is an invalid RedGifs URL.')
 
         # If it's a 'watch' URL
         if 'watch' in yarl_url.path:

--- a/redgifs/utils.py
+++ b/redgifs/utils.py
@@ -23,8 +23,9 @@ DEALINGS IN THE SOFTWARE.
 """
 
 import re
+import yarl
 
-from .const import REDGIFS_THUMBS_RE
+from .const import REDGIFS_THUMBS_RE, IP_ADDR_RE
 
 def _to_web_url(id_or_url: str, use_regex: bool = False) -> str:
     if not use_regex:
@@ -39,3 +40,10 @@ def _to_web_url(id_or_url: str, use_regex: bool = False) -> str:
         return f'https://redgifs.com/watch/{id.lower()}'
     except IndexError:
         return ''
+
+def strip_ip(url: str) -> str:
+    u = yarl.URL(url)
+    if u.query.get('for'):
+        for_value = re.sub(IP_ADDR_RE, 'REDACTED', u.query['for'])
+        return u % {'for': for_value}
+    return url

--- a/redgifs/utils.py
+++ b/redgifs/utils.py
@@ -25,7 +25,7 @@ DEALINGS IN THE SOFTWARE.
 import re
 import yarl
 
-from .const import REDGIFS_THUMBS_RE, IP_ADDR_RE
+from .const import REDGIFS_THUMBS_RE
 
 def _to_web_url(id_or_url: str, use_regex: bool = False) -> str:
     if not use_regex:
@@ -44,6 +44,5 @@ def _to_web_url(id_or_url: str, use_regex: bool = False) -> str:
 def strip_ip(url: str) -> str:
     u = yarl.URL(url)
     if u.query.get('for'):
-        for_value = re.sub(IP_ADDR_RE, 'REDACTED', u.query['for'])
-        return u % {'for': for_value}
+        return u % {'for': 'REDACTED'}
     return url


### PR DESCRIPTION
## Summary
This PR prevents anyone using this library from getting their IP address leaked due to error messages.

## Some background
Someone reported an issue on this repository but they didn't read the error properly. This error contained a redgifs url which has their IP address.

## Why this may be an issue
1. On Discord bots, when an error occurs it normally prints the error to stderr. But in same cases, the bot devs would like to send the error in the Discord server so that other users understand what the error is. But this causes an issue as the IP address of the host gets leaked.

2. New users who use this library may not read the full error. As a result, they may unknowingly post the error (along with their IP) on websites such as StackOverflow to ask for help.