### PR TITLE
Handle downloading `files.redgifs.com` URLs

### DIFF
--- a/redgifs/const.py
+++ b/redgifs/const.py
@@ -28,6 +28,10 @@ REDGIFS_THUMBS_RE = re.compile(
     r'https://thumbs\d+?\.redgifs\.com/(?P<id>\w+)(?P<type>-\w+)?\.(?P<ext>\w+)(\?.+(\d|\w))?'
 )
 
+REDGIFS_FILES_RE = re.compile(
+    r'https://files\.redgifs\.com/(?P<id>\w+)\.(?P<ext>\w+)'
+)
+
 REDGIFS_ID_RE = re.compile(
     r'https://(thumbs(\d+)|api)\.redgifs\.com/(?P<id>[a-zA-Z]+)'
 )

--- a/redgifs/http.py
+++ b/redgifs/http.py
@@ -39,7 +39,7 @@ import yarl
 from . import __version__
 from .errors import HTTPException
 from .enums import Order, Type
-from .const import REDGIFS_THUMBS_RE
+from .const import REDGIFS_FILES_RE, REDGIFS_THUMBS_RE
 from .utils import strip_ip
 
 __all__ = ('ProxyAuth',)
@@ -251,6 +251,13 @@ class HTTP:
         # If it's a direct URL
         if all([x in str(yarl_url.host) for x in ['thumbs', 'redgifs']]):
             match = re.match(REDGIFS_THUMBS_RE, str_url)
+            if match:
+                return (dl(str_url))
+            raise TypeError(f'"{strip_ip(str_url)}" is an invalid RedGifs URL.')
+
+        # If it's a 'files' URL
+        if all([x in str(yarl_url.host) for x in ['files', 'redgifs']]):
+            match = re.match(REDGIFS_FILES_RE, str_url)
             if match:
                 return (dl(str_url))
             raise TypeError(f'"{strip_ip(str_url)}" is an invalid RedGifs URL.')


### PR DESCRIPTION
Some download URLs are now redirecting to `files.redgifs.com` direct downloads. Example traceback:
```python
Traceback (most recent call last):
  ....
  File "/home/flagarby/scripts/link_dropper.py", line 158, in drop_redgifs
    rg_api.download(gif.urls.hd, f)
  File "/home/flagarby/.pyenv/versions/scripts/lib/python3.10/site-packages/redgifs/api.py", line 394, in download
    return self.http.download(url, fp)
  File "/home/flagarby/.pyenv/versions/scripts/lib/python3.10/site-packages/redgifs/http.py", line 263, in download
    raise TypeError(f'"{strip_ip(str_url)}" is an invalid RedGifs URL.')
TypeError: "https://files.redgifs.com/SomeRandomIdentifier.mp4" is an invalid RedGifs URL.
```