### PR TITLE
Raise HTTPException instead of TypeError when the API provides a detailed error response in downloading

### DIFF
--- a/redgifs/api.py
+++ b/redgifs/api.py
@@ -137,8 +137,8 @@ class API:
             published=json['published'],
             urls=URL(
                 sd=urls['sd'],
-                hd=urls['hd'],
-                poster=urls['poster'],
+                hd=urls['hd'] if 'hd' in urls else None,
+                poster=urls['poster'] if 'poster' in urls else None,
                 thumbnail=urls['thumbnail'],
                 vthumbnail=urls.get('vthumbnail'),
                 web_url=to_web_url(json['id']),

--- a/redgifs/http.py
+++ b/redgifs/http.py
@@ -239,7 +239,8 @@ class HTTP:
                     raise HTTPException(r, json)
                 except:
                     raise HTTPException(r, None)
-            if content_type != 'video/mp4':
+                
+            if content_type not in ('video/mp4', 'image/jpeg'):
                 _log.error(f'GET {url} returned improper content-type: {content_type}')
                 raise TypeError(f'"{url}" returned invalid content type for downloading: {content_type}')
 

--- a/redgifs/http.py
+++ b/redgifs/http.py
@@ -233,6 +233,12 @@ class HTTP:
             _log.debug(f'GET {url} returned code: {r.status_code}')
 
             content_type = r.headers['Content-Type']
+            if content_type.startswith('application/json'):
+                try:
+                    json = r.json()
+                    raise HTTPException(r, json)
+                except:
+                    raise HTTPException(r, None)
             if content_type != 'video/mp4':
                 _log.error(f'GET {url} returned improper content-type: {content_type}')
                 raise TypeError(f'"{url}" returned invalid content type for downloading: {content_type}')

--- a/redgifs/models.py
+++ b/redgifs/models.py
@@ -58,8 +58,8 @@ class URL:
     __slots__ = ('sd', 'hd', 'poster', 'thumbnail', 'vthumbnail', 'web_url', 'file_url', 'embed_url')
 
     sd: str
-    hd: str
-    poster: str
+    hd: Optional[str]
+    poster: Optional[str]
     thumbnail: str
     vthumbnail: Optional[str]
     web_url: str


### PR DESCRIPTION
This was a quick fix for my needs. The async version should be updated too of course. The HTTPException provides `status` which is very useful in determining that an item is deleted (e.g. 404 or 410). It would be handy for me if this was merged upstream, but I'm opening this PR more as a suggestion than anything else.

By the way, thanks for your work, it is really helpful!