### PR TITLE
Allow some urls to be missing

### DIFF
--- a/redgifs/api.py
+++ b/redgifs/api.py
@@ -137,8 +137,8 @@ class API:
             published=json['published'],
             urls=URL(
                 sd=urls['sd'],
-                hd=urls['hd'] if 'hd' in urls else None,
-                poster=urls['poster'] if 'poster' in urls else None,
+                hd=urls.get('hd'),
+                poster=urls.get('poster'),
                 thumbnail=urls['thumbnail'],
                 vthumbnail=urls.get('vthumbnail'),
                 web_url=to_web_url(json['id']),

--- a/redgifs/api.py
+++ b/redgifs/api.py
@@ -137,8 +137,8 @@ class API:
             published=json['published'],
             urls=URL(
                 sd=urls['sd'],
-                hd=urls['hd'],
-                poster=urls['poster'],
+                hd=urls['hd'] if 'hd' in urls else None,
+                poster=urls['poster'] if 'poster' in urls else None,
                 thumbnail=urls['thumbnail'],
                 vthumbnail=urls.get('vthumbnail'),
                 web_url=to_web_url(json['id']),

--- a/redgifs/models.py
+++ b/redgifs/models.py
@@ -58,8 +58,8 @@ class URL:
     __slots__ = ('sd', 'hd', 'poster', 'thumbnail', 'vthumbnail', 'web_url', 'file_url', 'embed_url')
 
     sd: str
-    hd: str
-    poster: str
+    hd: Optional[str]
+    poster: Optional[str]
     thumbnail: str
     vthumbnail: Optional[str]
     web_url: str


### PR DESCRIPTION
In practice I have found that `hd` and `poster` URLs are not always present. They are almost always present, but I can provide some IDs for cases where these are missing. Unfortunately, they are NSFW videos, so I will exclude these IDs for now. If they are of interest, let me know, and I'll leave them in a comment.