### PR TITLE
test: :zap: Add conftest.py to sleep beween tests (rate limit)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,29 @@
+"""
+Pytest configuration for the test suite.
+
+This file defines an autouse fixture that adds a one-second delay before
+running tests that perform real API calls to Redgifs. This helps avoid
+hitting rate limits during the online tests without affecting offline ones.
+"""
+
+import time
+import pytest
+
+# List of files which really use online API (and can be rate-limited)
+ONLINE_TEST_FILES = {
+    "test_gif_creator_attrs.py",
+    "test_images_attrs.py",
+    "test_order.py",
+    "test_routes.py",
+}
+
+@pytest.fixture(autouse=True)
+def slow_down_for_online_tests(request):
+    """
+    Adds a short delay before running tests that perform real API calls.
+
+    This helps avoid hitting Redgifs rate limits during the test suite.
+    """
+    test_file = request.fspath.basename
+    if test_file in ONLINE_TEST_FILES:
+        time.sleep(1)


### PR DESCRIPTION
Hi !

I don't know if you will find it usefull, but as I said on Discord, I made a little conftest.py, to force a sleep(1) beween each test that calls the API. (it just looks for the files that make queries to the API, so 
```python
ONLINE_TEST_FILES = {
    "test_gif_creator_attrs.py",
    "test_images_attrs.py",
    "test_order.py",
    "test_routes.py",
}
```

Nothing fancy, but can be usefull, for your github action, if you plan to test it agains 3.8, 3.9, etc 3.14 and more.

It wille take more time, but I think it can avoid rate-limit 429.