### PR TITLE
feat: Context managers (with...)

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,33 @@ loop = asyncio.get_event_loop()
 loop.run_until_complete(main())
 ```
 
+#### 4. Context managers:
+
+Context managers for automatic usage of login() and close() are available :
+```python
+from redgifs import API # note this
+
+with API() as api:
+    response = api.search('latina', count=4)
+
+print(response.gifs[0])
+```
+
+or async :
+```python
+import asyncio
+from redgifs.aio import API # note this
+
+async def main():
+    async with API() as api:
+        response = await api.search('latina', count=4)
+
+    print(response.gifs[0])
+
+loop = asyncio.get_event_loop()
+loop.run_until_complete(main())  # run
+```
+
 More examples can be found in the examples directory.
 
 -----

--- a/examples/context_async.py
+++ b/examples/context_async.py
@@ -1,0 +1,13 @@
+import asyncio
+from redgifs.aio import API # note this
+
+async def main():
+    async with API() as api:
+        response = await api.search('latina', count=4)
+
+    print(response.gifs[0])  # pyright: ignore[reportOptionalSubscript]
+
+
+# MAIN
+loop = asyncio.get_event_loop()
+loop.run_until_complete(main())

--- a/examples/context_sync.py
+++ b/examples/context_sync.py
@@ -1,0 +1,6 @@
+from redgifs import API # note this
+
+with API() as api:
+    response = api.search('latina', count=4)
+
+print(response.gifs[0])  # pyright: ignore[reportOptionalSubscript]

--- a/redgifs/aio.py
+++ b/redgifs/aio.py
@@ -422,3 +422,12 @@ class API:
     async def close(self) -> None:
         """Closes the API session."""
         return await self.http.close()
+
+    async def __aenter__(self):
+        """Context manager."""
+        await self.login()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        """Context manager."""
+        await self.close()

--- a/redgifs/api.py
+++ b/redgifs/api.py
@@ -415,3 +415,12 @@ class API:
     def close(self) -> None:
         """Closes the API session."""
         return self.http.close()
+
+    def __enter__(self):
+        """Context manager."""
+        self.login()
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        """Context manager."""
+        self.close()


### PR DESCRIPTION
Hi.

I added the context managers.

Nothing super fancy.

Just allows to do :

```python
from redgifs import API # note this

with API() as api:
    response = api.search('latina', count=4)

print(response.gifs[0]) 
```

(sync and async versions)

Provided with an update to the README file, and some examples.

Let me know if it needs some changes.