### PR TITLE
docs: fix README success output spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ $ redgifs https://redgifs.com/users/usernamethatexists -f rg_vids
 Downloaded 1/3 GIFs
 Downloaded 2/3 GIFs
 ...
-Downloaded 3/3 videos of user usernamethatexists to folder rg_vids sucessfully!
+Downloaded 3/3 videos of user usernamethatexists to folder rg_vids successfully!
 ```
 </details>
 


### PR DESCRIPTION
## Summary
- update the README profile-download example output to spell "successfully" correctly
- keep the example aligned with the existing CLI source message in `redgifs/__main__.py`

## Validation
- `rg -n "sucessfully|successfully|Downloaded 3/3 videos|folder_info" README.md redgifs/__main__.py`
- `python3 -m py_compile redgifs/__main__.py`
- `git diff --check`